### PR TITLE
fix: suppress hydration warning on body

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,10 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </head>
-      <body suppressHydrationWarning className="font-body antialiased">
+      <body
+        className="font-body antialiased"
+        suppressHydrationWarning // Prevent hydration mismatches from extensions
+      >
         {children}
         <Toaster />
       </body>


### PR DESCRIPTION
## Summary
- ensure body element ignores hydration mismatches caused by extensions

## Testing
- `npm run lint`
- `npm run typecheck`
